### PR TITLE
Hashed Table Tests

### DIFF
--- a/src/main/java/thkoeln/st/springtestlib/specification/table/Cell.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/Cell.java
@@ -7,6 +7,7 @@ import java.util.List;
 public class Cell {
 
     private List<String> contents = new ArrayList<>();
+    private String hashedContent;
     private String[] validCellValues;
     private boolean caseSensitive = false;
 
@@ -60,6 +61,10 @@ public class Cell {
 
         Cell otherCell = (Cell)obj;
 
+        if (hashedContent != null && otherCell.hashedContent != null) {
+            return hashedContent.equals(otherCell.hashedContent);
+        }
+
         if (contents.size() != otherCell.contents.size()) {
             return false;
         }
@@ -72,9 +77,22 @@ public class Cell {
         return true;
     }
 
-    public static Cell parseCell(String content, String[] validCellValues, boolean caseSensitive) {
+    @Override
+    public String toString() {
+        if (hashedContent != null) {
+            return hashedContent;
+        }
+        return String.join(", ", contents);
+    }
+
+    public static Cell parseCell(String content, String[] validCellValues, boolean caseSensitive, boolean isHashed, boolean shouldBeHash) {
         Cell newCell = new Cell( validCellValues );
         newCell.setCaseSensitive( caseSensitive );
+
+        if (isHashed) {
+            newCell.hashedContent = content;
+            return newCell;
+        }
 
         String[] split = content.split(",");
         for (String s : split) {
@@ -85,13 +103,22 @@ public class Cell {
             }
         }
 
+        if (shouldBeHash) {
+            newCell.contents.sort(String::compareToIgnoreCase);
+            String joinedContent = String.join(",", newCell.contents);
+            try {
+                if (caseSensitive) {
+                    newCell.hashedContent = Hashing.hashString(joinedContent);
+                } else {
+                    newCell.hashedContent = Hashing.hashString(joinedContent.toLowerCase());
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
         return newCell;
     }
-
-    public static Cell parseCell(String content, String[] validCellValues) {
-        return parseCell(content, validCellValues, false);
-    }
-
 
     public boolean isEmpty() {
         return contents.isEmpty();
@@ -103,5 +130,9 @@ public class Cell {
 
     public void setCaseSensitive( boolean caseSensitive ) {
         this.caseSensitive = caseSensitive;
+    }
+
+    public String getHashedContent() {
+        return hashedContent;
     }
 }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/Cell.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/Cell.java
@@ -85,11 +85,11 @@ public class Cell {
         return String.join(", ", contents);
     }
 
-    public static Cell parseCell(String content, String[] validCellValues, boolean caseSensitive, boolean isHashed, boolean shouldBeHash) {
+    public static Cell parseCell(String content, String[] validCellValues, boolean caseSensitive, boolean isCellHashed, boolean shouldCellBeHashed) {
         Cell newCell = new Cell( validCellValues );
         newCell.setCaseSensitive( caseSensitive );
 
-        if (isHashed) {
+        if (isCellHashed) {
             newCell.hashedContent = content;
             return newCell;
         }
@@ -103,7 +103,7 @@ public class Cell {
             }
         }
 
-        if (shouldBeHash) {
+        if (shouldCellBeHashed) {
             newCell.contents.sort(String::compareToIgnoreCase);
             String joinedContent = String.join(",", newCell.contents);
             try {

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
@@ -95,5 +95,10 @@ public class GenericTableSpecificationTests {
         for (String line : fileLines) {
             System.out.println(line);
         }
+        var br = new BufferedWriter(new FileWriter(path));
+        for (String line : fileLines) {
+            br.write(line + System.lineSeparator());
+        }
+        br.close();
     }
 }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
@@ -25,6 +25,13 @@ public class GenericTableSpecificationTests {
         return table;
     }
 
+    private Table loadTable2(String path, TableConfig tableConfig, boolean isTableHashed, boolean shouldTableBeHashed) throws Exception {
+        List<String> fileLines = loadFileLines2(path);
+        Table table = createTable(tableConfig);
+        table.parse(fileLines, isTableHashed, shouldTableBeHashed);
+        return table;
+    }
+
     private List<String> loadFileLines(String path) throws Exception {
         List<String> fileLines = new ArrayList<>();
 
@@ -44,6 +51,21 @@ public class GenericTableSpecificationTests {
         return fileLines;
     }
 
+    private List<String> loadFileLines2(String path) throws Exception {
+        List<String> fileLines = new ArrayList<>();
+        File file = new File(path);
+        if (!file.exists()) {
+            throw new FileNotFoundException("File not found: " + path);
+        }
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(file)))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                fileLines.add(line);
+            }
+        }
+        return fileLines;
+    }
+
     private TableConfig loadTableConfig(String tableConfigPath) throws IOException {
         InputStream inputStream = this.getClass()
                 .getClassLoader()
@@ -52,6 +74,16 @@ public class GenericTableSpecificationTests {
             throw new FileNotFoundException("Table Config not found: " + tableConfigPath);
         }
         return objectMapper.readValue(new InputStreamReader(inputStream), TableConfig.class);
+    }
+
+    private TableConfig loadTableConfig2(String tableConfigPath) throws IOException {
+        File configFile = new File(tableConfigPath);
+        if (!configFile.exists()) {
+            throw new FileNotFoundException("Table Config not found: " + tableConfigPath);
+        }
+        try (FileInputStream inputStream = new FileInputStream(configFile)) {
+            return objectMapper.readValue(new InputStreamReader(inputStream), TableConfig.class);
+        }
     }
 
     public void testTableSpecification(String expectedPath, String actualPath, String tableConfigPath, boolean isExpectedTableHashed) throws Exception {
@@ -112,8 +144,8 @@ public class GenericTableSpecificationTests {
     }
 
     public void hashTable(String inputPath, String outputPath, String tableConfigPath) throws Exception {
-        TableConfig tableConfig = loadTableConfig(tableConfigPath);
-        Table inputTable = loadTable(inputPath, tableConfig, false, true);
+        TableConfig tableConfig = loadTableConfig2(tableConfigPath);
+        Table inputTable = loadTable2(inputPath, tableConfig, false, true);
         saveTable(outputPath, inputTable);
     }
 

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
@@ -7,22 +7,21 @@ import thkoeln.st.springtestlib.specification.table.implementations.OrderedOnlyC
 import thkoeln.st.springtestlib.specification.table.implementations.RowsAndColumnsTable;
 import thkoeln.st.springtestlib.specification.table.implementations.SequencedOnlyColumnsTable;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class GenericTableSpecificationTests {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
 
-    private Table loadTable(String path, TableType tableType, TableConfig tableConfig) throws Exception {
+    private Table loadTable(String path, TableType tableType, TableConfig tableConfig, boolean isHashed) throws Exception {
         List<String> fileLines = loadFileLines(path);
         Table table = createTable(tableType, tableConfig);
-        table.parse(fileLines);
+        table.parse(fileLines, isHashed);
         return table;
     }
 
@@ -50,18 +49,18 @@ public class GenericTableSpecificationTests {
         return objectMapper.readValue(new InputStreamReader(inputStream), TableConfig.class);
     }
 
-    public void testTableSpecification(String expectedPath, String actualPath, String tableConfigPath, TableType tableType) throws Exception {
+    public void testTableSpecification(String expectedPath, String actualPath, String tableConfigPath, TableType tableType, boolean isExpectedTableHashed) throws Exception {
         TableConfig tableConfig = loadTableConfig(tableConfigPath);
 
-        Table expectedTable = loadTable(expectedPath, tableType, tableConfig);
-        Table actualTable = loadTable(actualPath, tableType, tableConfig);
+        Table expectedTable = loadTable(expectedPath, tableType, tableConfig, isExpectedTableHashed);
+        Table actualTable = loadTable(actualPath, tableType, tableConfig, false);
 
         expectedTable.compareToActualTable(actualTable);
     }
 
     public void testTableSyntax(String actualPath, String tableConfigPath, TableType tableType) throws Exception {
         TableConfig tableConfig = loadTableConfig(tableConfigPath);
-        loadTable(actualPath, tableType, tableConfig);
+        loadTable(actualPath, tableType, tableConfig, false);
     }
 
     private Table createTable(TableType tableType, TableConfig tableConfig) {
@@ -76,6 +75,25 @@ public class GenericTableSpecificationTests {
                 return new SequencedOnlyColumnsTable(tableConfig);
             default:
                 throw new IllegalArgumentException("This table type does not exist");
+        }
+    }
+
+    public void hashTable(String inputPath, String outputPath, String tableConfigPath, TableType tableType) throws Exception {
+        TableConfig tableConfig = loadTableConfig(tableConfigPath);
+        Table inputTable = loadTable(inputPath, tableType, tableConfig, false);
+        saveTable(outputPath, inputTable);
+    }
+
+    public void saveTable(String path, Table table) throws Exception {
+        List<String> fileLines = Arrays.stream(table.toString().split("\n")).collect(Collectors.toList());
+        saveFileLines(path, fileLines);
+    }
+
+    private void saveFileLines(String path, List<String> fileLines) throws Exception {
+        System.out.println("Saving file to " + path);
+        System.out.println("File content:");
+        for (String line : fileLines) {
+            System.out.println(line);
         }
     }
 }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
@@ -18,10 +18,10 @@ public class GenericTableSpecificationTests {
     private ObjectMapper objectMapper = new ObjectMapper();
 
 
-    private Table loadTable(String path, TableConfig tableConfig, boolean isHashed, boolean shouldBeHashed) throws Exception {
+    private Table loadTable(String path, TableConfig tableConfig, boolean isTableHashed, boolean shouldTableBeHashed) throws Exception {
         List<String> fileLines = loadFileLines(path);
         Table table = createTable(tableConfig);
-        table.parse(fileLines, isHashed, shouldBeHashed);
+        table.parse(fileLines, isTableHashed, shouldTableBeHashed);
         return table;
     }
 
@@ -31,6 +31,9 @@ public class GenericTableSpecificationTests {
         InputStream inputStream = this.getClass()
                 .getClassLoader()
                 .getResourceAsStream(path);
+        if (inputStream == null) {
+            throw new FileNotFoundException("File not found: " + path);
+        }
         BufferedReader br = new BufferedReader(new InputStreamReader(inputStream));
 
         String line;
@@ -58,9 +61,29 @@ public class GenericTableSpecificationTests {
         expectedTable.compareToActualTable(actualTable);
     }
 
+    public void testTableSpecification(String tableNamePrefix) throws Exception {
+        var expectedPath = tableNamePrefix + "-solution.md";
+        var expectedHashedPath = tableNamePrefix + "-hashed-solution.md";
+        var actualPath = tableNamePrefix + ".md";
+        var tableConfigPath = tableNamePrefix + "-config.json";
+        try {
+            testTableSpecification(expectedPath, actualPath, tableConfigPath, false);
+        } catch (FileNotFoundException e) {
+            if (e.getMessage().contains(expectedPath)) {
+                testTableSpecification(expectedHashedPath, actualPath, tableConfigPath, true);
+            }
+        }
+    }
+
     public void testTableSyntax(String actualPath, String tableConfigPath) throws Exception {
         TableConfig tableConfig = loadTableConfig(tableConfigPath);
         loadTable(actualPath, tableConfig, false, false);
+    }
+
+    public void testTableSyntax(String tableNamePrefix) throws Exception {
+        var actualPath = tableNamePrefix + ".md";
+        var tableConfigPath = tableNamePrefix + "-config.json";
+        testTableSyntax(actualPath, tableConfigPath);
     }
 
     private Table createTable(TableConfig tableConfig) {

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
@@ -32,7 +32,7 @@ public class GenericTableSpecificationTests {
                 .getClassLoader()
                 .getResourceAsStream(path);
         if (inputStream == null) {
-            throw new FileNotFoundException("File not found: " + path);
+            throw new FileNotFoundException("Table not found: " + path);
         }
         BufferedReader br = new BufferedReader(new InputStreamReader(inputStream));
 
@@ -48,7 +48,9 @@ public class GenericTableSpecificationTests {
         InputStream inputStream = this.getClass()
                 .getClassLoader()
                 .getResourceAsStream(tableConfigPath);
-
+        if (inputStream == null) {
+            throw new FileNotFoundException("Table Config not found: " + tableConfigPath);
+        }
         return objectMapper.readValue(new InputStreamReader(inputStream), TableConfig.class);
     }
 
@@ -61,11 +63,7 @@ public class GenericTableSpecificationTests {
         expectedTable.compareToActualTable(actualTable);
     }
 
-    public void testTableSpecification(String tableNamePrefix) throws Exception {
-        var expectedPath = tableNamePrefix + "-solution.md";
-        var expectedHashedPath = tableNamePrefix + "-hashed-solution.md";
-        var actualPath = tableNamePrefix + ".md";
-        var tableConfigPath = tableNamePrefix + "-config.json";
+    public void testTableSpecification(String expectedPath, String expectedHashedPath, String actualPath, String tableConfigPath) throws Exception {
         try {
             testTableSpecification(expectedPath, actualPath, tableConfigPath, false);
         } catch (FileNotFoundException e) {
@@ -73,6 +71,18 @@ public class GenericTableSpecificationTests {
                 testTableSpecification(expectedHashedPath, actualPath, tableConfigPath, true);
             }
         }
+    }
+
+    public void testTableSpecification(String tableNamePrefix) throws Exception {
+        var expectedPath = tableNamePrefix + "-solution.md";
+        var expectedHashedPath = tableNamePrefix + "-hashed-solution.md";
+        var actualPath = tableNamePrefix + ".md";
+        var tableConfigPath = tableNamePrefix + "-config.json";
+        testTableSpecification(expectedPath, expectedHashedPath, actualPath, tableConfigPath);
+    }
+
+    public void testTableSpecification(String expectedPath, String actualPath, String tableConfigPath) throws Exception {
+        testTableSpecification(expectedPath, actualPath, tableConfigPath, false);
     }
 
     public void testTableSyntax(String actualPath, String tableConfigPath) throws Exception {

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
@@ -18,10 +18,10 @@ public class GenericTableSpecificationTests {
     private ObjectMapper objectMapper = new ObjectMapper();
 
 
-    private Table loadTable(String path, TableConfig tableConfig, boolean isHashed) throws Exception {
+    private Table loadTable(String path, TableConfig tableConfig, boolean isHashed, boolean shouldBeHashed) throws Exception {
         List<String> fileLines = loadFileLines(path);
         Table table = createTable(tableConfig);
-        table.parse(fileLines, isHashed);
+        table.parse(fileLines, isHashed, shouldBeHashed);
         return table;
     }
 
@@ -52,15 +52,15 @@ public class GenericTableSpecificationTests {
     public void testTableSpecification(String expectedPath, String actualPath, String tableConfigPath, boolean isExpectedTableHashed) throws Exception {
         TableConfig tableConfig = loadTableConfig(tableConfigPath);
 
-        Table expectedTable = loadTable(expectedPath, tableConfig, isExpectedTableHashed);
-        Table actualTable = loadTable(actualPath, tableConfig, false);
+        Table expectedTable = loadTable(expectedPath, tableConfig, isExpectedTableHashed, false);
+        Table actualTable = loadTable(actualPath, tableConfig, false, isExpectedTableHashed);
 
         expectedTable.compareToActualTable(actualTable);
     }
 
     public void testTableSyntax(String actualPath, String tableConfigPath) throws Exception {
         TableConfig tableConfig = loadTableConfig(tableConfigPath);
-        loadTable(actualPath, tableConfig, false);
+        loadTable(actualPath, tableConfig, false, false);
     }
 
     private Table createTable(TableConfig tableConfig) {
@@ -80,7 +80,7 @@ public class GenericTableSpecificationTests {
 
     public void hashTable(String inputPath, String outputPath, String tableConfigPath) throws Exception {
         TableConfig tableConfig = loadTableConfig(tableConfigPath);
-        Table inputTable = loadTable(inputPath, tableConfig, false);
+        Table inputTable = loadTable(inputPath, tableConfig, false, true);
         saveTable(outputPath, inputTable);
     }
 

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/GenericTableSpecificationTests.java
@@ -18,9 +18,9 @@ public class GenericTableSpecificationTests {
     private ObjectMapper objectMapper = new ObjectMapper();
 
 
-    private Table loadTable(String path, TableType tableType, TableConfig tableConfig, boolean isHashed) throws Exception {
+    private Table loadTable(String path, TableConfig tableConfig, boolean isHashed) throws Exception {
         List<String> fileLines = loadFileLines(path);
-        Table table = createTable(tableType, tableConfig);
+        Table table = createTable(tableConfig);
         table.parse(fileLines, isHashed);
         return table;
     }
@@ -49,22 +49,22 @@ public class GenericTableSpecificationTests {
         return objectMapper.readValue(new InputStreamReader(inputStream), TableConfig.class);
     }
 
-    public void testTableSpecification(String expectedPath, String actualPath, String tableConfigPath, TableType tableType, boolean isExpectedTableHashed) throws Exception {
+    public void testTableSpecification(String expectedPath, String actualPath, String tableConfigPath, boolean isExpectedTableHashed) throws Exception {
         TableConfig tableConfig = loadTableConfig(tableConfigPath);
 
-        Table expectedTable = loadTable(expectedPath, tableType, tableConfig, isExpectedTableHashed);
-        Table actualTable = loadTable(actualPath, tableType, tableConfig, false);
+        Table expectedTable = loadTable(expectedPath, tableConfig, isExpectedTableHashed);
+        Table actualTable = loadTable(actualPath, tableConfig, false);
 
         expectedTable.compareToActualTable(actualTable);
     }
 
-    public void testTableSyntax(String actualPath, String tableConfigPath, TableType tableType) throws Exception {
+    public void testTableSyntax(String actualPath, String tableConfigPath) throws Exception {
         TableConfig tableConfig = loadTableConfig(tableConfigPath);
-        loadTable(actualPath, tableType, tableConfig, false);
+        loadTable(actualPath, tableConfig, false);
     }
 
-    private Table createTable(TableType tableType, TableConfig tableConfig) {
-        switch (tableType) {
+    private Table createTable(TableConfig tableConfig) {
+        switch (tableConfig.getTableType()) {
             case ROWS_AND_COLUMNS:
                 return new RowsAndColumnsTable(tableConfig);
             case ORDERED_ONLY_COLUMNS:
@@ -78,9 +78,9 @@ public class GenericTableSpecificationTests {
         }
     }
 
-    public void hashTable(String inputPath, String outputPath, String tableConfigPath, TableType tableType) throws Exception {
+    public void hashTable(String inputPath, String outputPath, String tableConfigPath) throws Exception {
         TableConfig tableConfig = loadTableConfig(tableConfigPath);
-        Table inputTable = loadTable(inputPath, tableType, tableConfig, false);
+        Table inputTable = loadTable(inputPath, tableConfig, false);
         saveTable(outputPath, inputTable);
     }
 

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/Hashing.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/Hashing.java
@@ -1,0 +1,36 @@
+package thkoeln.st.springtestlib.specification.table;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class Hashing {
+
+  public static String hashString(String input) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] encodedhash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+      return bytesToHex(encodedhash);
+    } catch (NoSuchAlgorithmException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+
+  public static String hashString(String input, String salt) {
+    // TODO: Implement salted hashing
+    return null;
+  }
+
+  private static String bytesToHex(byte[] hash) {
+    StringBuilder hexString = new StringBuilder(2 * hash.length);
+    for (byte b : hash) {
+      String hex = Integer.toHexString(0xff & b);
+      if (hex.length() == 1) {
+        hexString.append('0');
+      }
+      hexString.append(hex);
+    }
+    return hexString.toString();
+  }
+}

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/Table.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/Table.java
@@ -279,11 +279,11 @@ public abstract class Table {
         }
 
         for (int i = 2; i < contentLines.size(); i++) {
-            addRow(null, isHashed, tableConfig.shouldRowBeHashed());
+            addRow(null, isHashed, false);
             String[] columns = parseElementsInContentLine(contentLines.get(i));
             for (int j = 0; j < columns.length; j++) {
                 String[] validCellValues = getValidCellValues(i-2, j);
-                Cell newCell = Cell.parseCell( columns[j], validCellValues, tableConfig.isCaseSensitiveColumn( j ), isHashed, tableConfig.shouldCellBeHashed() );
+                Cell newCell = Cell.parseCell( columns[j], validCellValues, tableConfig.isCaseSensitiveColumn( j ), isHashed, tableConfig.shouldColumnBeHashed( j ) );
                 setCell(i-2, j, newCell );
             }
         }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/Table.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/Table.java
@@ -270,7 +270,7 @@ public abstract class Table {
         return message;
     }
 
-    public void parse(List<String> contentLines, boolean isHashed, boolean shouldBeHashed) {
+    public void parse(List<String> contentLines, boolean isTableHashed, boolean shouldTableBeHashed) {
         contentLines = testSyntax(filterContentLines(contentLines));
 
         String[] columnNames = parseElementsInContentLine(contentLines.get(0));
@@ -279,11 +279,17 @@ public abstract class Table {
         }
 
         for (int i = 2; i < contentLines.size(); i++) {
-            addRow(null, isHashed, false);
+            addRow(null, isTableHashed, false);
             String[] columns = parseElementsInContentLine(contentLines.get(i));
             for (int j = 0; j < columns.length; j++) {
                 String[] validCellValues = getValidCellValues(i-2, j);
-                Cell newCell = Cell.parseCell( columns[j], validCellValues, tableConfig.isCaseSensitiveColumn( j ), isHashed, tableConfig.shouldColumnBeHashed( j ) && shouldBeHashed );
+                Cell newCell = Cell.parseCell(
+                    columns[j],
+                    validCellValues,
+                    tableConfig.isCaseSensitiveColumn(j),
+                    tableConfig.isHashedColumn(j) && isTableHashed,
+                    tableConfig.isHashedColumn(j) && shouldTableBeHashed
+                );
                 setCell(i-2, j, newCell );
             }
         }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/Table.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/Table.java
@@ -7,8 +7,6 @@ import java.util.stream.IntStream;
 
 public abstract class Table {
 
-    protected TableType tableType;
-
     protected List<String> rows = new ArrayList<>();
     protected List<String> columns = new ArrayList<>();
     protected List<List<Cell>> cells = new ArrayList<>();
@@ -16,9 +14,7 @@ public abstract class Table {
     protected TableConfig tableConfig;
 
 
-    public Table(TableType tableType, TableConfig tableConfig) {
-        this.tableType = tableType;
-
+    public Table(TableConfig tableConfig) {
         this.tableConfig = tableConfig;
     }
 

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/Table.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/Table.java
@@ -3,6 +3,7 @@ package thkoeln.st.springtestlib.specification.table;
 import java.util.ArrayList;
 import java.util.InputMismatchException;
 import java.util.List;
+import java.util.stream.IntStream;
 
 public abstract class Table {
 
@@ -21,7 +22,15 @@ public abstract class Table {
         this.tableConfig = tableConfig;
     }
 
-    public void addRow(String rowName) {
+    public void addRow(String rowName, boolean isHashed, boolean shouldRowBeHashed) {
+        if (!isHashed && shouldRowBeHashed) {
+            try {
+                rowName = Hashing.hashString(rowName);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
         if (!isRowValid(rowName)) {
             throw new InputMismatchException("\"" + rowName + "\" is not a valid row name");
         }
@@ -265,7 +274,7 @@ public abstract class Table {
         return message;
     }
 
-    public void parse(List<String> contentLines) {
+    public void parse(List<String> contentLines, boolean isHashed) {
         contentLines = testSyntax(filterContentLines(contentLines));
 
         String[] columnNames = parseElementsInContentLine(contentLines.get(0));
@@ -274,13 +283,83 @@ public abstract class Table {
         }
 
         for (int i = 2; i < contentLines.size(); i++) {
-            addRow(null);
+            addRow(null, isHashed, tableConfig.shouldRowBeHashed());
             String[] columns = parseElementsInContentLine(contentLines.get(i));
             for (int j = 0; j < columns.length; j++) {
                 String[] validCellValues = getValidCellValues(i-2, j);
-                Cell newCell = Cell.parseCell( columns[j], validCellValues, tableConfig.isCaseSensitiveColumn( j ) );
+                Cell newCell = Cell.parseCell( columns[j], validCellValues, tableConfig.isCaseSensitiveColumn( j ), isHashed, tableConfig.shouldCellBeHashed() );
                 setCell(i-2, j, newCell );
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        List<String> headers = getHeaderRow();
+
+        // Max lengths
+        int[] maxLengths = headers.stream()
+            .mapToInt(String::length)
+            .toArray();
+
+        for (int i = 0; i < getHeight(); i++) {
+            for (int j = 0; j < getWidth(); j++) {
+                maxLengths[j] = Math.max(maxLengths[j], getStringAtPosition(i, j).length());
+            }
+        }
+
+        // Header
+        String[] headersPadded = headers.stream()
+            .map(s -> s + " ".repeat(Math.max(0, maxLengths[headers.indexOf(s)] - s.length())))
+            .toArray(String[]::new);
+
+        sb.append("| ");
+        sb.append(String.join(" | ", headersPadded));
+        sb.append(" |");
+        sb.append("\n");
+
+        // Separator
+        String[] separators = IntStream.range(0, getWidth())
+            .mapToObj(i -> "-".repeat(maxLengths[i] + 2))
+            .toArray(String[]::new);
+
+        sb.append("|");
+        sb.append(String.join("|", separators));
+        sb.append("|");
+        sb.append("\n");
+
+        // Rows
+        for (int i = 1; i < getHeight(); i++) {
+            List<String> row = new ArrayList<>();
+            for (int j = 0; j < getWidth(); j++) {
+                row.add(getStringAtPosition(i, j) + " ".repeat(Math.max(0, maxLengths[j] - getStringAtPosition(i, j).length())));
+            }
+
+            sb.append("| ");
+            sb.append(String.join(" | ", row));
+            sb.append(" |");
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    protected int getWidth() {
+        return columns.size();
+    }
+
+    protected int getHeight() {
+        return rows.size() + 1;
+    }
+
+    protected List<String> getHeaderRow() {
+      return new ArrayList<>(columns);
+    }
+
+    protected String getStringAtPosition(int row, int column) {
+        if (row == 0)
+            return columns.get(column);
+        return getCell(row-1, column).toString();
     }
 }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/Table.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/Table.java
@@ -270,7 +270,7 @@ public abstract class Table {
         return message;
     }
 
-    public void parse(List<String> contentLines, boolean isHashed) {
+    public void parse(List<String> contentLines, boolean isHashed, boolean shouldBeHashed) {
         contentLines = testSyntax(filterContentLines(contentLines));
 
         String[] columnNames = parseElementsInContentLine(contentLines.get(0));
@@ -283,7 +283,7 @@ public abstract class Table {
             String[] columns = parseElementsInContentLine(contentLines.get(i));
             for (int j = 0; j < columns.length; j++) {
                 String[] validCellValues = getValidCellValues(i-2, j);
-                Cell newCell = Cell.parseCell( columns[j], validCellValues, tableConfig.isCaseSensitiveColumn( j ), isHashed, tableConfig.shouldColumnBeHashed( j ) );
+                Cell newCell = Cell.parseCell( columns[j], validCellValues, tableConfig.isCaseSensitiveColumn( j ), isHashed, tableConfig.shouldColumnBeHashed( j ) && shouldBeHashed );
                 setCell(i-2, j, newCell );
             }
         }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/TableConfig.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/TableConfig.java
@@ -1,19 +1,25 @@
 package thkoeln.st.springtestlib.specification.table;
 
 public class TableConfig {
+    private TableType tableType;
     private String[] explanationDimensions;
     private String[] validRowValues;
     private String[] validColumnValues;
     private String[] validCellValues;
     private boolean[] caseSensitiveColumns;
+    private boolean[] hashedColumns;
 
     private boolean showRowHints;
     private boolean showColumnHints;
 
-    private boolean[] shouldColumnsBeHashed;
 
-    private TableType tableType;
+    public TableType getTableType() {
+        return tableType;
+    }
 
+    public void setTableType(TableType tableType) {
+        this.tableType = tableType;
+    }
 
     public String[] getExplanationDimensions() {
         return explanationDimensions;
@@ -78,26 +84,18 @@ public class TableConfig {
         this.caseSensitiveColumns = caseSensitiveColumns;
     }
 
-    public boolean shouldColumnBeHashed( int column ) {
-        if ( shouldColumnsBeHashed == null || column < 0 || column >= shouldColumnsBeHashed.length ) {
+    public boolean isHashedColumn( int column ) {
+        if ( hashedColumns == null || column < 0 || column >= hashedColumns.length ) {
             return false;
         }
-        return shouldColumnsBeHashed[column];
+        return hashedColumns[column];
     }
 
-    public boolean[] shouldColumnsBeHashed() {
-        return shouldColumnsBeHashed;
+    public boolean[] getHashedColumns() {
+        return hashedColumns;
     }
 
-    public void setShouldColumnsBeHashed( boolean[] shouldColumnsBeHashed ) {
-        this.shouldColumnsBeHashed = shouldColumnsBeHashed;
-    }
-
-    public TableType getTableType() {
-        return tableType;
-    }
-
-    public void setTableType(TableType tableType) {
-        this.tableType = tableType;
+    public void setHashedColumns(boolean[] hashedColumns) {
+        this.hashedColumns = hashedColumns;
     }
 }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/TableConfig.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/TableConfig.java
@@ -10,8 +10,7 @@ public class TableConfig {
     private boolean showRowHints;
     private boolean showColumnHints;
 
-    private boolean shouldCellBeHashed;
-    private boolean shouldRowBeHashed;
+    private boolean[] shouldColumnsBeHashed;
 
     private TableType tableType;
 
@@ -79,21 +78,19 @@ public class TableConfig {
         this.caseSensitiveColumns = caseSensitiveColumns;
     }
 
-
-    public boolean shouldCellBeHashed() {
-        return shouldCellBeHashed;
+    public boolean shouldColumnBeHashed( int column ) {
+        if ( shouldColumnsBeHashed == null || column < 0 || column >= shouldColumnsBeHashed.length ) {
+            return false;
+        }
+        return shouldColumnsBeHashed[column];
     }
 
-    public void setShouldCellBeHashed( boolean shouldCellBeHashed ) {
-        this.shouldCellBeHashed = shouldCellBeHashed;
+    public boolean[] shouldColumnsBeHashed() {
+        return shouldColumnsBeHashed;
     }
 
-    public boolean shouldRowBeHashed() {
-        return shouldRowBeHashed;
-    }
-
-    public void setShouldRowBeHashed( boolean shouldRowBeHashed ) {
-        this.shouldRowBeHashed = shouldRowBeHashed;
+    public void setShouldColumnsBeHashed( boolean[] shouldColumnsBeHashed ) {
+        this.shouldColumnsBeHashed = shouldColumnsBeHashed;
     }
 
     public TableType getTableType() {

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/TableConfig.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/TableConfig.java
@@ -13,6 +13,8 @@ public class TableConfig {
     private boolean shouldCellBeHashed;
     private boolean shouldRowBeHashed;
 
+    private TableType tableType;
+
 
     public String[] getExplanationDimensions() {
         return explanationDimensions;
@@ -92,5 +94,13 @@ public class TableConfig {
 
     public void setShouldRowBeHashed( boolean shouldRowBeHashed ) {
         this.shouldRowBeHashed = shouldRowBeHashed;
+    }
+
+    public TableType getTableType() {
+        return tableType;
+    }
+
+    public void setTableType(TableType tableType) {
+        this.tableType = tableType;
     }
 }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/TableConfig.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/TableConfig.java
@@ -10,6 +10,9 @@ public class TableConfig {
     private boolean showRowHints;
     private boolean showColumnHints;
 
+    private boolean shouldCellBeHashed;
+    private boolean shouldRowBeHashed;
+
 
     public String[] getExplanationDimensions() {
         return explanationDimensions;
@@ -72,5 +75,22 @@ public class TableConfig {
 
     public void setCaseSensitiveColumns( boolean[] caseSensitiveColumns ) {
         this.caseSensitiveColumns = caseSensitiveColumns;
+    }
+
+
+    public boolean shouldCellBeHashed() {
+        return shouldCellBeHashed;
+    }
+
+    public void setShouldCellBeHashed( boolean shouldCellBeHashed ) {
+        this.shouldCellBeHashed = shouldCellBeHashed;
+    }
+
+    public boolean shouldRowBeHashed() {
+        return shouldRowBeHashed;
+    }
+
+    public void setShouldRowBeHashed( boolean shouldRowBeHashed ) {
+        this.shouldRowBeHashed = shouldRowBeHashed;
     }
 }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/OrderedOnlyColumnsTable.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/OrderedOnlyColumnsTable.java
@@ -10,7 +10,7 @@ public class OrderedOnlyColumnsTable extends Table {
 
 
     public OrderedOnlyColumnsTable(TableConfig tableConfig) {
-        super(TableType.ORDERED_ONLY_COLUMNS, tableConfig);
+        super(tableConfig);
     }
 
     @Override

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/RowsAndColumnsTable.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/RowsAndColumnsTable.java
@@ -48,7 +48,7 @@ public class RowsAndColumnsTable extends Table {
     }
 
     @Override
-    public void parse(List<String> contentLines, boolean isHashed) {
+    public void parse(List<String> contentLines, boolean isHashed, boolean shouldBeHashed) {
         contentLines = testSyntax(filterContentLines(contentLines));
 
         String[] columnNames = parseElementsInContentLine(contentLines.get(0));
@@ -59,10 +59,10 @@ public class RowsAndColumnsTable extends Table {
 
         for (int i = 2; i < contentLines.size(); i++) {
             String[] columns = parseElementsInContentLine(contentLines.get(i));
-            addRow(columns[0], isHashed, tableConfig.shouldColumnBeHashed(0));
+            addRow(columns[0], isHashed, tableConfig.shouldColumnBeHashed(0) && shouldBeHashed);
             for (int j = 1; j < columns.length; j++) {
                 String[] validCellValues = getValidCellValues(i-2, j-1);
-                Cell newCell = Cell.parseCell(columns[j], validCellValues, tableConfig.isCaseSensitiveColumn(j), isHashed, tableConfig.shouldColumnBeHashed(j) );
+                Cell newCell = Cell.parseCell(columns[j], validCellValues, tableConfig.isCaseSensitiveColumn(j), isHashed, tableConfig.shouldColumnBeHashed(j) && shouldBeHashed);
                 setCell(i-2, j-1, newCell );
             }
         }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/RowsAndColumnsTable.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/RowsAndColumnsTable.java
@@ -48,7 +48,7 @@ public class RowsAndColumnsTable extends Table {
     }
 
     @Override
-    public void parse(List<String> contentLines, boolean isHashed, boolean shouldBeHashed) {
+    public void parse(List<String> contentLines, boolean isTableHashed, boolean shouldTableBeHashed) {
         contentLines = testSyntax(filterContentLines(contentLines));
 
         String[] columnNames = parseElementsInContentLine(contentLines.get(0));
@@ -59,10 +59,16 @@ public class RowsAndColumnsTable extends Table {
 
         for (int i = 2; i < contentLines.size(); i++) {
             String[] columns = parseElementsInContentLine(contentLines.get(i));
-            addRow(columns[0], isHashed, tableConfig.shouldColumnBeHashed(0) && shouldBeHashed);
+            addRow(columns[0], isTableHashed, tableConfig.isHashedColumn(0) && shouldTableBeHashed);
             for (int j = 1; j < columns.length; j++) {
                 String[] validCellValues = getValidCellValues(i-2, j-1);
-                Cell newCell = Cell.parseCell(columns[j], validCellValues, tableConfig.isCaseSensitiveColumn(j), isHashed, tableConfig.shouldColumnBeHashed(j) && shouldBeHashed);
+                Cell newCell = Cell.parseCell(
+                    columns[j],
+                    validCellValues,
+                    tableConfig.isCaseSensitiveColumn(j),
+                    tableConfig.isHashedColumn(j) && isTableHashed,
+                    tableConfig.isHashedColumn(j) && shouldTableBeHashed
+                );
                 setCell(i-2, j-1, newCell );
             }
         }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/RowsAndColumnsTable.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/RowsAndColumnsTable.java
@@ -9,7 +9,7 @@ public class RowsAndColumnsTable extends Table {
     private String rowColumn;
 
     public RowsAndColumnsTable(TableConfig tableConfig) {
-        super(TableType.ROWS_AND_COLUMNS, tableConfig);
+        super(tableConfig);
     }
 
 

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/RowsAndColumnsTable.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/RowsAndColumnsTable.java
@@ -59,10 +59,10 @@ public class RowsAndColumnsTable extends Table {
 
         for (int i = 2; i < contentLines.size(); i++) {
             String[] columns = parseElementsInContentLine(contentLines.get(i));
-            addRow(columns[0], isHashed, tableConfig.shouldRowBeHashed());
+            addRow(columns[0], isHashed, tableConfig.shouldColumnBeHashed(0));
             for (int j = 1; j < columns.length; j++) {
                 String[] validCellValues = getValidCellValues(i-2, j-1);
-                Cell newCell = Cell.parseCell(columns[j], validCellValues, tableConfig.isCaseSensitiveColumn(j), isHashed, tableConfig.shouldCellBeHashed() );
+                Cell newCell = Cell.parseCell(columns[j], validCellValues, tableConfig.isCaseSensitiveColumn(j), isHashed, tableConfig.shouldColumnBeHashed(j) );
                 setCell(i-2, j-1, newCell );
             }
         }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/SequencedOnlyColumnsTable.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/SequencedOnlyColumnsTable.java
@@ -13,7 +13,7 @@ public class SequencedOnlyColumnsTable extends Table {
 
 
     public SequencedOnlyColumnsTable(TableConfig tableConfig) {
-        super(TableType.SEQUENCED_ONLY_COLUMNS, tableConfig);
+        super(tableConfig);
     }
 
     @Override

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/SequencedOnlyColumnsTable.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/SequencedOnlyColumnsTable.java
@@ -71,8 +71,8 @@ public class SequencedOnlyColumnsTable extends Table {
     }
 
     @Override
-    public void parse(List<String> contentLines) {
-        super.parse(contentLines);
+    public void parse(List<String> contentLines, boolean isHashed) {
+        super.parse(contentLines, isHashed);
 
         findDuplicateEntries();
     }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/SequencedOnlyColumnsTable.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/SequencedOnlyColumnsTable.java
@@ -71,8 +71,8 @@ public class SequencedOnlyColumnsTable extends Table {
     }
 
     @Override
-    public void parse(List<String> contentLines, boolean isHashed, boolean shouldBeHashed) {
-        super.parse(contentLines, isHashed, shouldBeHashed);
+    public void parse(List<String> contentLines, boolean isTableHashed, boolean shouldTableBeHashed) {
+        super.parse(contentLines, isTableHashed, shouldTableBeHashed);
 
         findDuplicateEntries();
     }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/SequencedOnlyColumnsTable.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/SequencedOnlyColumnsTable.java
@@ -71,8 +71,8 @@ public class SequencedOnlyColumnsTable extends Table {
     }
 
     @Override
-    public void parse(List<String> contentLines, boolean isHashed) {
-        super.parse(contentLines, isHashed);
+    public void parse(List<String> contentLines, boolean isHashed, boolean shouldBeHashed) {
+        super.parse(contentLines, isHashed, shouldBeHashed);
 
         findDuplicateEntries();
     }

--- a/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/UnorderedOnlyColumnsTable.java
+++ b/src/main/java/thkoeln/st/springtestlib/specification/table/implementations/UnorderedOnlyColumnsTable.java
@@ -9,7 +9,7 @@ public class UnorderedOnlyColumnsTable extends Table {
 
 
     public UnorderedOnlyColumnsTable(TableConfig tableConfig) {
-        super(TableType.UNORDERED_ONLY_COLUMNS, tableConfig);
+        super(tableConfig);
     }
 
     @Override

--- a/src/test/java/thkoeln/st/springtestlib/specification/table/RowAndColumnTests.java
+++ b/src/test/java/thkoeln/st/springtestlib/specification/table/RowAndColumnTests.java
@@ -108,7 +108,7 @@ public class RowAndColumnTests {
                 assertDoesNotThrow(() -> {
                     genericTableSpecificationTests.hashTable(
                         getStudentTable( testCaseName, "ok" ),
-                        getSolution( testCaseName ),
+                        "src/test/resources/" + getSolution( testCaseName ),
                         getConfig( testCaseName ) );
                 });
                 assertDoesNotThrow( () -> {

--- a/src/test/java/thkoeln/st/springtestlib/specification/table/RowAndColumnTests.java
+++ b/src/test/java/thkoeln/st/springtestlib/specification/table/RowAndColumnTests.java
@@ -29,7 +29,21 @@ public class RowAndColumnTests {
                 new TableTestAspect( "wrong-root", InputMismatchException.class,
                         "Too many rows." )
         } );
+        testCases.put( "Aggregates-Hashed", new TableTestAspect[] {
+            new TableTestAspect( "missing-inner", InputMismatchException.class,
+                "Cell content is not matching. Row: \"640935d4060f52abd3c391fe190f493db938b461f213986375e923970eb9059a\"" ),
+            new TableTestAspect( "surplus-inner", InputMismatchException.class,
+                "Cell content is not matching. Row: \"b6e3957877afbac525ff73eb32395fb9f6b1ff6ca664dfa6deb9cd9a69aaac7d\"" ),
+            new TableTestAspect( "wrong-root", InputMismatchException.class,
+                "Too many rows." )
+        } );
         testCases.put( "Rest", new TableTestAspect[] {
+            new TableTestAspect( "wrong-case", InputMismatchException.class,
+                "Cell content is not matching. Row: \"Get a specific space ship by ID\"" ),
+            new TableTestAspect( "wrong-verb", InputMismatchException.class,
+                "Cell content is not matching. Row: \"Create a new space ship\"" )
+        } );
+        testCases.put( "Rest-Hashed", new TableTestAspect[] {
                 new TableTestAspect( "wrong-case", InputMismatchException.class,
                         "Cell content is not matching. Row: \"Get a specific space ship by ID\"" ),
                 new TableTestAspect( "wrong-verb", InputMismatchException.class,
@@ -82,7 +96,33 @@ public class RowAndColumnTests {
                             getSolution( testCaseName ),
                             getStudentTable( testCaseName, "ok" ),
                             getConfig( testCaseName ),
-                            TableType.ROWS_AND_COLUMNS );
+                            TableType.ROWS_AND_COLUMNS,
+                            testCaseName.contains("-Hashed"));
+                });
+            }
+        }
+    }
+
+    @Test
+    public void testSaveTables() {
+        for (Map.Entry<String, TableTestAspect[]> entry : testCases.entrySet()) {
+            for (TableTestAspect aspect : entry.getValue()) {
+                String testCaseName = entry.getKey();
+                System.out.println("Testing " + testCaseName + " with " + aspect.getAspectName());
+                assertDoesNotThrow(() -> {
+                    genericTableSpecificationTests.hashTable(
+                        getStudentTable( testCaseName, "ok" ),
+                        getSolution( testCaseName ),
+                        getConfig( testCaseName ),
+                        TableType.ROWS_AND_COLUMNS );
+                });
+                assertDoesNotThrow( () -> {
+                    genericTableSpecificationTests.testTableSpecification(
+                        getSolution( testCaseName ),
+                        getStudentTable( testCaseName, "ok" ),
+                        getConfig( testCaseName ),
+                        TableType.ROWS_AND_COLUMNS,
+                        testCaseName.contains("-Hashed"));
                 });
             }
         }
@@ -99,7 +139,8 @@ public class RowAndColumnTests {
                             getSolution( testCaseName ),
                             getStudentTable( testCaseName, aspect.getAspectName() ),
                             getConfig( testCaseName ),
-                            TableType.ROWS_AND_COLUMNS ); });
+                            TableType.ROWS_AND_COLUMNS,
+                            testCaseName.contains("-Hashed")); });
                 assertEquals( aspect.getExpectedExceptionMessage(), exception.getMessage() );
             }
         }

--- a/src/test/java/thkoeln/st/springtestlib/specification/table/RowAndColumnTests.java
+++ b/src/test/java/thkoeln/st/springtestlib/specification/table/RowAndColumnTests.java
@@ -107,9 +107,9 @@ public class RowAndColumnTests {
                 System.out.println("Testing " + testCaseName + " with " + aspect.getAspectName());
                 assertDoesNotThrow(() -> {
                     genericTableSpecificationTests.hashTable(
-                        getStudentTable( testCaseName, "ok" ),
+                        "src/test/resources/" + getStudentTable( testCaseName, "ok" ),
                         "src/test/resources/" + getSolution( testCaseName ),
-                        getConfig( testCaseName ) );
+                        "src/test/resources/" + getConfig( testCaseName ) );
                 });
                 assertDoesNotThrow( () -> {
                     genericTableSpecificationTests.testTableSpecification(

--- a/src/test/java/thkoeln/st/springtestlib/specification/table/RowAndColumnTests.java
+++ b/src/test/java/thkoeln/st/springtestlib/specification/table/RowAndColumnTests.java
@@ -60,8 +60,7 @@ public class RowAndColumnTests {
                 assertDoesNotThrow( () -> {
                     genericTableSpecificationTests.testTableSyntax(
                             getStudentTable( testCaseName, aspect.getAspectName() ),
-                            getConfig( testCaseName ),
-                            TableType.ROWS_AND_COLUMNS );
+                            getConfig( testCaseName ) );
                 });
             }
         }
@@ -72,15 +71,13 @@ public class RowAndColumnTests {
         Throwable exception = assertThrows( InputMismatchException.class, () -> {
             genericTableSpecificationTests.testTableSyntax(
                     getStudentTable( "Aggregates", "invalid-syntax1" ),
-                    getConfig( "Aggregates" ),
-                    TableType.ROWS_AND_COLUMNS ); });
+                    getConfig( "Aggregates" ) ); });
         assertEquals( "Each table line needs the same number of \"|\" chars", exception.getMessage() );
 
         exception = assertThrows( InputMismatchException.class, () -> {
                     genericTableSpecificationTests.testTableSyntax(
                             getStudentTable( "Aggregates", "invalid-syntax2" ),
-                            getConfig( "Aggregates" ),
-                            TableType.ROWS_AND_COLUMNS ); });
+                            getConfig( "Aggregates" ) ); });
                 assertEquals( "Each table line needs the same number of \"|\" chars", exception.getMessage() );
     }
 
@@ -96,7 +93,6 @@ public class RowAndColumnTests {
                             getSolution( testCaseName ),
                             getStudentTable( testCaseName, "ok" ),
                             getConfig( testCaseName ),
-                            TableType.ROWS_AND_COLUMNS,
                             testCaseName.contains("-Hashed"));
                 });
             }
@@ -113,15 +109,13 @@ public class RowAndColumnTests {
                     genericTableSpecificationTests.hashTable(
                         getStudentTable( testCaseName, "ok" ),
                         getSolution( testCaseName ),
-                        getConfig( testCaseName ),
-                        TableType.ROWS_AND_COLUMNS );
+                        getConfig( testCaseName ) );
                 });
                 assertDoesNotThrow( () -> {
                     genericTableSpecificationTests.testTableSpecification(
                         getSolution( testCaseName ),
                         getStudentTable( testCaseName, "ok" ),
                         getConfig( testCaseName ),
-                        TableType.ROWS_AND_COLUMNS,
                         testCaseName.contains("-Hashed"));
                 });
             }
@@ -139,7 +133,6 @@ public class RowAndColumnTests {
                             getSolution( testCaseName ),
                             getStudentTable( testCaseName, aspect.getAspectName() ),
                             getConfig( testCaseName ),
-                            TableType.ROWS_AND_COLUMNS,
                             testCaseName.contains("-Hashed")); });
                 assertEquals( aspect.getExpectedExceptionMessage(), exception.getMessage() );
             }

--- a/src/test/resources/specification/table/Aggregates-Hashed-invalid-syntax1.md
+++ b/src/test/resources/specification/table/Aggregates-Hashed-invalid-syntax1.md
@@ -1,0 +1,6 @@
+| Aggregate root | other entities / domain primitives / other VOs                    |
+|----------------|-------------------------------------------------------------------|
+| JumpGate       | 
+| Planet         | mineralicore, CompassOrientation                                  |
+| spaceShip      | Task, Load,CompassOrientationPath,CompassOrientation,MineralicOre |
+

--- a/src/test/resources/specification/table/Aggregates-Hashed-invalid-syntax2.md
+++ b/src/test/resources/specification/table/Aggregates-Hashed-invalid-syntax2.md
@@ -1,0 +1,6 @@
+| Aggregate root | other entities / domain primitives / other VOs                    |
+|----------------|-------------------------------------------------------------------|
+| JumpGate       | |
+| Planet         | mineralicore, CompassOrientation                                  ||
+| spaceShip      | Task, Load,CompassOrientationPath,CompassOrientation,MineralicOre |
+

--- a/src/test/resources/specification/table/Aggregates-Hashed-missing-inner.md
+++ b/src/test/resources/specification/table/Aggregates-Hashed-missing-inner.md
@@ -1,0 +1,6 @@
+| Aggregate root | other entities / domain primitives / other VOs    |
+|----------------|---------------------------------------------------|
+| JumpGate       ||
+| Planet         | mineralicore, CompassOrientation                  |
+| spaceShip      | Task, Load,CompassOrientationPath,   MineralicOre |
+

--- a/src/test/resources/specification/table/Aggregates-Hashed-ok.md
+++ b/src/test/resources/specification/table/Aggregates-Hashed-ok.md
@@ -1,0 +1,6 @@
+| Aggregate root | other entities / domain primitives / other VOs                    |
+|----------------|-------------------------------------------------------------------|
+| JumpGate       ||
+| Planet         | mineralicore, CompassOrientation                                  |
+| spaceShip      | Task, Load,CompassOrientationPath,CompassOrientation,MineralicOre |
+

--- a/src/test/resources/specification/table/Aggregates-Hashed-surplus-inner.md
+++ b/src/test/resources/specification/table/Aggregates-Hashed-surplus-inner.md
@@ -1,0 +1,6 @@
+| Aggregate root | other entities / domain primitives / other VOs                    |
+|----------------|-------------------------------------------------------------------|
+| JumpGate       ||
+| Planet         | Knoedel, mineralicOre, CompassOrientation                         |
+| spaceShip      | Task, Load,CompassOrientationPath,CompassOrientation,MineralicOre |
+

--- a/src/test/resources/specification/table/Aggregates-Hashed-wrong-root.md
+++ b/src/test/resources/specification/table/Aggregates-Hashed-wrong-root.md
@@ -1,0 +1,7 @@
+| Aggregate root | other entities / domain primitives / other VOs                    |
+|----------------|-------------------------------------------------------------------|
+| JumpGate       ||
+| Planet         | mineralicore, CompassOrientation                                  |
+| MineralicOre   |                                                                   |
+| spaceShip      | Task, Load,CompassOrientationPath,CompassOrientation,MineralicOre |
+

--- a/src/test/resources/specification/table/REST-Hashed-ok.md
+++ b/src/test/resources/specification/table/REST-Hashed-ok.md
@@ -1,0 +1,19 @@
+| Requirement #                                                      | URI                               | VERB   |
+|--------------------------------------------------------------------|-----------------------------------|--------|
+| Get all space ships                                                | /spaceShips                       | Get    |
+| Create a new space ship                                            | /spaceShips                       | POST   |
+| Get a specific space ship by ID                                    | /spaceShips/{spaceShip-id}        | GET    |
+| Give a specific space ship a task                                  | /spaceShips/{spaceShip-id}/tasks  | POST   |
+| Get the task history for a specific space ship                     | /spaceShips/{spaceShip-id}/tasks  | GET    |
+| Clear the task history for a specific space ship                   | /spaceShips/{spaceShip-id}/tasks  | Delete |
+| Delete a specific space ship                                       | /spaceShips/{spaceShip-id}        | DELETE |
+| Load or unload some load of mineralic ore on a specific space ship | /spaceShips/{spaceShip-id}/load   | PUT    |
+| Get all planets                                                    | /planets                          | get    |
+| Get a specific planet by ID                                        | /planets/{planet-id}              | GeT    |
+| Replenish mineralic ore on a specific planet                       | /planets/{planet-id}/mineralicOre | PUT    |
+| Install a jump gate                                                | /jumpGates                        | POST   |
+| Get all jump gates currently installed                             | /jumpGates                        | GET    |
+| Get a specific jump gate                                           | /jumpGates/{jumpGate-id}          | GET    |
+| Shut down a specific jump gate                                     | /jumpGates/{jumpGate-id}          | DELETE |
+| Relocate a specific jump gate to another set of planets            | /jumpGates/{jumpGate-id}          | patch  |
+

--- a/src/test/resources/specification/table/REST-Hashed-wrong-case.md
+++ b/src/test/resources/specification/table/REST-Hashed-wrong-case.md
@@ -1,0 +1,19 @@
+| Requirement #                                                      | URI                                 | VERB   |
+|--------------------------------------------------------------------|-------------------------------------|--------|
+| Get all space ships                                                | /spaceShips                         | GET    |
+| Create a new space ship                                            | /spaceShips                         | POST   |
+| Get a specific space ship by ID                                    | /spaceships/{spaceShip-id}          | GET    |
+| Give a specific space ship a task                                  | /spaceShips/{spaceShip-id}/tasks    | POST   |
+| Get the task history for a specific space ship                     | /spaceShips/{spaceShip-id}/tasks    | GET    |
+| Clear the task history for a specific space ship                   | /spaceShips/{spaceShip-id}/tasks    | DELETE |
+| Delete a specific space ship                                       | /spaceShips/{spaceShip-id}          | DELETE |
+| Load or unload some load of mineralic ore on a specific space ship | /spaceShips/{spaceShip-id}/load     | PUT    |
+| Get all planets                                                    | /planets                            | GET    |
+| Get a specific planet by ID                                        | /planets/{planet-id}                | GET    |
+| Replenish mineralic ore on a specific planet                       | /planets/{planet-id}/mineralicOre   | PUT    |
+| Install a jump gate                                                | /jumpGates                          | POST   |
+| Get all jump gates currently installed                             | /jumpGates                          | GET    |
+| Get a specific jump gate                                           | /jumpGates/{jumpGate-id}            | GET    |
+| Shut down a specific jump gate                                     | /jumpGates/{jumpGate-id}            | DELETE |
+| Relocate a specific jump gate to another set of planets            | /jumpGates/{jumpGate-id}            | PATCH  |
+

--- a/src/test/resources/specification/table/REST-Hashed-wrong-verb.md
+++ b/src/test/resources/specification/table/REST-Hashed-wrong-verb.md
@@ -1,0 +1,19 @@
+| Requirement #                                                      | URI                               | VERB   |
+|--------------------------------------------------------------------|-----------------------------------|--------|
+| Get all space ships                                                | /spaceShips                       | Get    |
+| Create a new space ship                                            | /spaceShips                       | POS    |
+| Get a specific space ship by ID                                    | /spaceShips/{spaceShip-id}        | GET    |
+| Give a specific space ship a task                                  | /spaceShips/{spaceShip-id}/tasks  | POST   |
+| Get the task history for a specific space ship                     | /spaceShips/{spaceShip-id}/tasks  | GET    |
+| Clear the task history for a specific space ship                   | /spaceShips/{spaceShip-id}/tasks  | Delete |
+| Delete a specific space ship                                       | /spaceShips/{spaceShip-id}        | DELETE |
+| Load or unload some load of mineralic ore on a specific space ship | /spaceShips/{spaceShip-id}/load   | PUT    |
+| Get all planets                                                    | /planets                          | get    |
+| Get a specific planet by ID                                        | /planets/{planet-id}              | GT     |
+| Replenish mineralic ore on a specific planet                       | /planets/{planet-id}/mineralicOre | PUT    |
+| Install a jump gate                                                | /jumpGates                        | POST   |
+| Get all jump gates currently installed                             | /jumpGates                        | GET    |
+| Get a specific jump gate                                           | /jumpGates/{jumpGate-id}          | GET    |
+| Shut down a specific jump gate                                     | /jumpGates/{jumpGate-id}          | DELETE |
+| Relocate a specific jump gate to another set of planets            | /jumpGates/{jumpGate-id}          | patch  |
+

--- a/src/test/resources/specification/table/solutions/Aggregates-Hashed-config.json
+++ b/src/test/resources/specification/table/solutions/Aggregates-Hashed-config.json
@@ -1,4 +1,5 @@
 {
+  "tableType": "ROWS_AND_COLUMNS",
   "explanationDimensions": [],
   "validRowValues": [],
   "validColumnValues": [
@@ -6,8 +7,7 @@
     "other entities / domain primitives / other VOs"
   ],
   "validCellValues": [],
+  "hashedColumns": [true, true],
   "showRowHints": true,
-  "showColumnHints": false,
-  "shouldColumnsBeHashed": [true, true],
-  "tableType": "ROWS_AND_COLUMNS"
+  "showColumnHints": false
 }

--- a/src/test/resources/specification/table/solutions/Aggregates-Hashed-config.json
+++ b/src/test/resources/specification/table/solutions/Aggregates-Hashed-config.json
@@ -8,6 +8,6 @@
   "validCellValues": [],
   "showRowHints": true,
   "showColumnHints": false,
-  "shouldCellBeHashed": false,
-  "shouldRowBeHashed": false
+  "shouldCellBeHashed": true,
+  "shouldRowBeHashed": true
 }

--- a/src/test/resources/specification/table/solutions/Aggregates-Hashed-config.json
+++ b/src/test/resources/specification/table/solutions/Aggregates-Hashed-config.json
@@ -8,7 +8,6 @@
   "validCellValues": [],
   "showRowHints": true,
   "showColumnHints": false,
-  "shouldCellBeHashed": true,
-  "shouldRowBeHashed": true,
+  "shouldColumnsBeHashed": [true, true],
   "tableType": "ROWS_AND_COLUMNS"
 }

--- a/src/test/resources/specification/table/solutions/Aggregates-Hashed-config.json
+++ b/src/test/resources/specification/table/solutions/Aggregates-Hashed-config.json
@@ -9,5 +9,6 @@
   "showRowHints": true,
   "showColumnHints": false,
   "shouldCellBeHashed": true,
-  "shouldRowBeHashed": true
+  "shouldRowBeHashed": true,
+  "tableType": "ROWS_AND_COLUMNS"
 }

--- a/src/test/resources/specification/table/solutions/Aggregates-Hashed-solution.md
+++ b/src/test/resources/specification/table/solutions/Aggregates-Hashed-solution.md
@@ -1,0 +1,5 @@
+| Aggregate root                                                   | other entities / domain primitives / other VOs                   |
+|------------------------------------------------------------------|------------------------------------------------------------------|
+| 640935d4060f52abd3c391fe190f493db938b461f213986375e923970eb9059a | e0b7cc849c26ed11f6c209179f639b13936b7726bd0762a0abefbc08139af0fa |
+| b6e3957877afbac525ff73eb32395fb9f6b1ff6ca664dfa6deb9cd9a69aaac7d | 6a920899e14192ea7a9a6e591e6edccc6682f3beaeef052177c48062aa85c297 |
+| 6ca9a33e5f1b21ac950a3e539142ff4532497b25189fcbff9b51118ef056ee69 | e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 |

--- a/src/test/resources/specification/table/solutions/Aggregates-config.json
+++ b/src/test/resources/specification/table/solutions/Aggregates-config.json
@@ -9,5 +9,6 @@
   "showRowHints": true,
   "showColumnHints": false,
   "shouldCellBeHashed": false,
-  "shouldRowBeHashed": false
+  "shouldRowBeHashed": false,
+  "tableType": "ROWS_AND_COLUMNS"
 }

--- a/src/test/resources/specification/table/solutions/Aggregates-config.json
+++ b/src/test/resources/specification/table/solutions/Aggregates-config.json
@@ -1,4 +1,5 @@
 {
+  "tableType": "ROWS_AND_COLUMNS",
   "explanationDimensions": [],
   "validRowValues": [],
   "validColumnValues": [
@@ -6,8 +7,7 @@
     "other entities / domain primitives / other VOs"
   ],
   "validCellValues": [],
+  "hashedColumns": [false, false],
   "showRowHints": true,
-  "showColumnHints": false,
-  "shouldColumnsBeHashed": [false, false],
-  "tableType": "ROWS_AND_COLUMNS"
+  "showColumnHints": false
 }

--- a/src/test/resources/specification/table/solutions/Aggregates-config.json
+++ b/src/test/resources/specification/table/solutions/Aggregates-config.json
@@ -8,7 +8,6 @@
   "validCellValues": [],
   "showRowHints": true,
   "showColumnHints": false,
-  "shouldCellBeHashed": false,
-  "shouldRowBeHashed": false,
+  "shouldColumnsBeHashed": [false, false],
   "tableType": "ROWS_AND_COLUMNS"
 }

--- a/src/test/resources/specification/table/solutions/REST-Hashed-config.json
+++ b/src/test/resources/specification/table/solutions/REST-Hashed-config.json
@@ -14,6 +14,6 @@
   "validCellValues": [],
   "showRowHints": true,
   "showColumnHints": false,
-  "shouldCellBeHashed": false,
+  "shouldCellBeHashed": true,
   "shouldRowBeHashed": false
 }

--- a/src/test/resources/specification/table/solutions/REST-Hashed-config.json
+++ b/src/test/resources/specification/table/solutions/REST-Hashed-config.json
@@ -15,5 +15,6 @@
   "showRowHints": true,
   "showColumnHints": false,
   "shouldCellBeHashed": true,
-  "shouldRowBeHashed": false
+  "shouldRowBeHashed": false,
+  "tableType": "ROWS_AND_COLUMNS"
 }

--- a/src/test/resources/specification/table/solutions/REST-Hashed-config.json
+++ b/src/test/resources/specification/table/solutions/REST-Hashed-config.json
@@ -1,4 +1,5 @@
 {
+  "tableType": "ROWS_AND_COLUMNS",
   "explanationDimensions": [],
   "validRowValues": [],
   "validColumnValues": [
@@ -12,8 +13,7 @@
     "false"
   ],
   "validCellValues": [],
+  "hashedColumns": [false, true, true],
   "showRowHints": true,
-  "showColumnHints": false,
-  "shouldColumnsBeHashed": [false, true, true],
-  "tableType": "ROWS_AND_COLUMNS"
+  "showColumnHints": false
 }

--- a/src/test/resources/specification/table/solutions/REST-Hashed-config.json
+++ b/src/test/resources/specification/table/solutions/REST-Hashed-config.json
@@ -14,7 +14,6 @@
   "validCellValues": [],
   "showRowHints": true,
   "showColumnHints": false,
-  "shouldCellBeHashed": true,
-  "shouldRowBeHashed": false,
+  "shouldColumnsBeHashed": [false, true, true],
   "tableType": "ROWS_AND_COLUMNS"
 }

--- a/src/test/resources/specification/table/solutions/REST-Hashed-solution.md
+++ b/src/test/resources/specification/table/solutions/REST-Hashed-solution.md
@@ -1,0 +1,18 @@
+| Requirement #                                                      | URI                                                              | VERB                                                             |
+|--------------------------------------------------------------------|------------------------------------------------------------------|------------------------------------------------------------------|
+| Get all space ships                                                | 3bd8231361a9aebc833d17633da345657583681535569630dbf95c633417b128 | 2998b3232d29e8dc5a78d97a32ce83f556f3ed31b057077503df05641dd79158 |
+| Create a new space ship                                            | 3bd8231361a9aebc833d17633da345657583681535569630dbf95c633417b128 | 72231043bc1807e6f740b235eb7511ecb33255a6a375435631196de8a9750d4b |
+| Get a specific space ship by ID                                    | 89cdab058d32c7692105f1c67a8f30394aeec28b240763cd5c45aaf7a0baba9b | 2998b3232d29e8dc5a78d97a32ce83f556f3ed31b057077503df05641dd79158 |
+| Give a specific space ship a task                                  | 6f563778b0e675735f0bdd4b7113460f31c6d0f372783f91dd16d0c8af52fcfe | 72231043bc1807e6f740b235eb7511ecb33255a6a375435631196de8a9750d4b |
+| Get the task history for a specific space ship                     | 6f563778b0e675735f0bdd4b7113460f31c6d0f372783f91dd16d0c8af52fcfe | 2998b3232d29e8dc5a78d97a32ce83f556f3ed31b057077503df05641dd79158 |
+| Clear the task history for a specific space ship                   | 6f563778b0e675735f0bdd4b7113460f31c6d0f372783f91dd16d0c8af52fcfe | 6197595503f01ee2a34e403fe08d2e1d9d0c14cf1cdfc2b74739895dc9a15a04 |
+| Delete a specific space ship                                       | 89cdab058d32c7692105f1c67a8f30394aeec28b240763cd5c45aaf7a0baba9b | 6197595503f01ee2a34e403fe08d2e1d9d0c14cf1cdfc2b74739895dc9a15a04 |
+| Load or unload some load of mineralic ore on a specific space ship | d2be024476920a4ff66c065837d601b672f93413c9cfd8dca39d3dad69a416f8 | 373cb2c6d4fe2778441d4f0266505b699fa518d002e5793b87f9b48836de3f62 |
+| Get all planets                                                    | b689b304bae38323a58a4491409f13ff5a6e770ea001d29d06487c365ae9bec5 | 2998b3232d29e8dc5a78d97a32ce83f556f3ed31b057077503df05641dd79158 |
+| Get a specific planet by ID                                        | 383c5598bce3cb5b3e22fe6cb874c6d1d08be0756f9bf79c68cc5f8b74517629 | 2998b3232d29e8dc5a78d97a32ce83f556f3ed31b057077503df05641dd79158 |
+| Replenish mineralic ore on a specific planet                       | d255361c6e717dd97d51db6c682e05e14184da3b9979540a09a74b01452fed18 | 373cb2c6d4fe2778441d4f0266505b699fa518d002e5793b87f9b48836de3f62 |
+| Install a jump gate                                                | e546b546f38bc3dc711e8a98b1f5805c91fff92f589e93ecd711e6c02146c37b | 72231043bc1807e6f740b235eb7511ecb33255a6a375435631196de8a9750d4b |
+| Get all jump gates currently installed                             | e546b546f38bc3dc711e8a98b1f5805c91fff92f589e93ecd711e6c02146c37b | 2998b3232d29e8dc5a78d97a32ce83f556f3ed31b057077503df05641dd79158 |
+| Get a specific jump gate                                           | 442b06faa1980172305b2eb3fbba1d48167eecb5cf52245eedee89591c856b50 | 2998b3232d29e8dc5a78d97a32ce83f556f3ed31b057077503df05641dd79158 |
+| Shut down a specific jump gate                                     | 442b06faa1980172305b2eb3fbba1d48167eecb5cf52245eedee89591c856b50 | 6197595503f01ee2a34e403fe08d2e1d9d0c14cf1cdfc2b74739895dc9a15a04 |
+| Relocate a specific jump gate to another set of planets            | 442b06faa1980172305b2eb3fbba1d48167eecb5cf52245eedee89591c856b50 | a4895eb44afc336fecbba6e520cd67e178dace0276655d102fceffa8e5f70570 |

--- a/src/test/resources/specification/table/solutions/REST-config.json
+++ b/src/test/resources/specification/table/solutions/REST-config.json
@@ -14,7 +14,6 @@
   "validCellValues": [],
   "showRowHints": true,
   "showColumnHints": false,
-  "shouldCellBeHashed": false,
-  "shouldRowBeHashed": false,
+  "shouldColumnsBeHashed": [false, false, false],
   "tableType": "ROWS_AND_COLUMNS"
 }

--- a/src/test/resources/specification/table/solutions/REST-config.json
+++ b/src/test/resources/specification/table/solutions/REST-config.json
@@ -1,4 +1,5 @@
 {
+  "tableType": "ROWS_AND_COLUMNS",
   "explanationDimensions": [],
   "validRowValues": [],
   "validColumnValues": [
@@ -12,8 +13,7 @@
     "false"
   ],
   "validCellValues": [],
+  "hashedColumns": [false, false, false],
   "showRowHints": true,
-  "showColumnHints": false,
-  "shouldColumnsBeHashed": [false, false, false],
-  "tableType": "ROWS_AND_COLUMNS"
+  "showColumnHints": false
 }

--- a/src/test/resources/specification/table/solutions/REST-config.json
+++ b/src/test/resources/specification/table/solutions/REST-config.json
@@ -15,5 +15,6 @@
   "showRowHints": true,
   "showColumnHints": false,
   "shouldCellBeHashed": false,
-  "shouldRowBeHashed": false
+  "shouldRowBeHashed": false,
+  "tableType": "ROWS_AND_COLUMNS"
 }


### PR DESCRIPTION
## Breaking Change
`testTableSpecification` and `testTableSyntax` do not accept TableType attribute anymore. Now it is part of TableConfig.

`void testTableSpecification(String expectedPath, String actualPath, String tableConfigPath, TableType tableType)`
-> `void testTableSpecification(String expectedPath, String actualPath, String tableConfigPath)`

`void testTableSyntax(String actualPath, String tableConfigPath, TableType tableType)`
-> `void testTableSyntax(String actualPath, String tableConfigPath)`

## Added
`Table::toString` to visualize tables as markdown
`TableConfig.tableType` attribute
`TableConfig.hashedColumns` analog zu `TableConfig.caseSensitiveColumns`

In `GenericTableSpecificationTests` sind neue Methoden dazu gekommen:

`void testTableSpecification(String expectedPath, String actualPath, String tableConfigPath, boolean isExpectedTableHashed)`
Diese Methode bergleicht die Tabelle unter expectedPath mi der unter actualPath und hashed letztere, wenn isExpectedTableHashed true ist.

`void testTableSpecification(String expectedPath, String expectedHashedPath, String actualPath, String tableConfigPath)`
Diese Methode nimmt sowohl einen Pfad für eine gehashte als auch eine ungehashte Lösungstabelle und versucht zuerst, die actual Tabelle mit der gehashten zu vergleichen, wenn diese nicht existiert, dann wird die actual Tabelle gehasht und mit der gehashten Lösungstabelle verglichen.
